### PR TITLE
Use `any Sendable` instead of `Any`

### DIFF
--- a/examples/EmbeddingSearch/EmbeddingSearch/ContentViewModel.swift
+++ b/examples/EmbeddingSearch/EmbeddingSearch/ContentViewModel.swift
@@ -94,7 +94,7 @@ struct QueryResult: Hashable, Identifiable {
 }
 
 extension QueryResult {
-    init?(_ result: [String: Any]) {
+    init?(_ result: [String: any Sendable]) {
         guard let id = result["id"] as? Int else {
             return nil
         }

--- a/examples/EmbeddingSearch/EmbeddingSearch/EmbeddingDatabase.swift
+++ b/examples/EmbeddingSearch/EmbeddingSearch/EmbeddingDatabase.swift
@@ -63,7 +63,7 @@ actor EmbeddingDatabase {
         )
     }
 
-    func querySimilar(to text: String, k: Int = 5) async throws -> [[String: Any]] {
+    func querySimilar(to text: String, k: Int = 5) async throws -> [[String: any Sendable]] {
         guard let vector = embeddingProvider.vector(for: text) else {
             throw EmbeddingDatabase.Error.cannotCreateVector
         }


### PR DESCRIPTION
Silences Swift 6 non-sendable type errors.